### PR TITLE
fixed spacing issue in GitShell tutorial

### DIFF
--- a/dh-courses-Common/explainGitShell.html
+++ b/dh-courses-Common/explainGitShell.html
@@ -204,28 +204,28 @@
             GitHub allows multiple collaborators to manage a repository. The only way to handle
             collaborators is through the web interface:</p>
         <ol>
-            <li><p>Go to <a href="https://www.github.com">https://www.github.com</a></p></li>
-            <li><p>Sign in and navigate to your profile.</p>
+            <li>Go to <a href="https://www.github.com">https://www.github.com</a></li>
+            <li>Sign in and navigate to your profile.
                 <p><img src="git_shell/addCollaborator_00.jpg" alt="Adding a Collaborator" /></p>
             </li>
-            <li><p>Choose the <q>repositories</q> tab from your profile.</p>
+            <li>Choose the repositories tab from your profile.
             </li>
-            <li><p>Select the repo to which you want to add a collaborator.</p>
+            <li>Select the repo to which you want to add a collaborator.
                 <p><img src="git_shell/addCollaborator_01.jpg" alt="Adding a Collaborator" /></p>
             </li>
-            <li><p>Select <q>Settings</q> at the top of the screen.</p>
+            <li>Select Settings at the top of the screen.
                 <p><img src="git_shell/addCollaborator_02.jpg" alt="Adding a Collaborator"
                  /></p></li>
-            <li><p>On the Settings page, move to the menu on the left side of the page, and select
-                        <q>Collaborators</q></p>
+            <li>On the Settings page, move to the menu on the left side of the page, and select
+                        Collaborators
                 <p><img src="git_shell/addCollaborator_03.jpg" alt="Adding a Collaborator"
                  /></p></li>
             <li>
-                <p>Type the user name of the collaborator you want to add. (This means that you’ll
+                Type the user name of the collaborator you want to add. (This means that you’ll
                     need to ask your collaborators to tell you their GitHub user names in advance.)
                     As you type, a drop down list will be generated matching what you have typed.
-                    Select the user you would like to add from the list. Then click <q>Add
-                        collaborator</q>.</p></li>
+                    Select the user you would like to add from the list. Then click Add
+                        collaborator.</li>
         </ol>
         <h3 id="cloning">Cloning</h3>
         <p>As we explain above, the way you work on your project (create files, edit files, delete
@@ -235,7 +235,7 @@
             that you can begin to work on it there is called cloning. You only have to clone a
             project once, when you first begin to work on it. Cloning is the copying of a project
             already in existence to your local computer so that you can begin to work on it;
-            whereas, <em>syncing</em> is exchanging updates between your local computer and the
+            whereas, syncing is exchanging updates between your local computer and the
             GitHub server after you’ve already cloned the repo and established a local copy in which
             you can work). This working model separates saving your work to your local computer
             (which you should do very frequently) and syncing your local clone of the repo with the


### PR DESCRIPTION
@ebeshero I noticed there was some weird spacing going on on the tutorial so i fixed it and I also removed some of the inline tags that transferred over from work I did on the Obdurodon GitHub tutorial  and reused in this new tutorial. 
