### PR TITLE
edited XSLT Exercise 1 to include the previously optional challenge from XSLT Exercise 1 for the CDA course

### DIFF
--- a/cdv-course/XSLTExercise1_CDV.html
+++ b/cdv-course/XSLTExercise1_CDV.html
@@ -1,0 +1,72 @@
+
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html xmlns="http://www.w3.org/1999/xhtml">
+   
+   	
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+      <link rel="stylesheet" type="text/css" href="explain.css" />
+      <title>XSLT Exercise 1</title>
+   </head>
+   
+   
+   
+   <body>
+      <!--#include virtual="top.html" -->
+      		
+      			
+      <h1><span class="banner">XSLT Exercise 1</span></h1>
+      			
+      			
+      			
+      			
+      <p>Our very first XSLT assignment is an Identity Transformation, a kind transformation we have to do frequently in our projects when we need to make specific changes to our encoding. We want to make some small changes in our Georg Forster file to make better choices of TEI elements for some of our tags.</p>
+      <p>To begin, download the Georg Forster file from here: <a href="ForsterGeorgComplete.xml">ForsterGeorgComplete.xml</a> and open it in &lt;oXygen&gt;. We don’t want to change much about this file, but we do want to alter its tagging just a little, and that is a good occasion to write an Identity Transformation XSLT, converting our XML to XML that is meant to be (for the most part) <em>identical</em> to the original.</p>
+      <p>Here are two changes we want to make to our XML file:</p> 
+      <ul><li>Looking through the file in the Outline view, we notice that our <span class="code">&lt;head&gt;</span> elements inside each <span class="code">&lt;div type="chapter"&gt;</span> are holding <span class="code">&lt;l&gt;</span> elements, which we originally applied to preserve line breaks in the original document. But we really should not be using the <span class="code">&lt;l&gt;</span> element, because in TEI that element is reserved for a line of poetry! We should change our tagging, and we think we should instead <em>end</em> each line with the self-closing <span class="code">&lt;lb/&gt;</span> element used to record a (non-poetry) line-break in TEI.</li>
+         <li>Scrolling through the document, we notice we have used <span class="code">&lt;emph&gt;</span> elements in TEI when we wanted to indicate a rendering in italics in the original. Just like the problem with the use of <span class="code">&lt;l&gt;</span>, that was a mistaken application of the TEI (even though it looks perfectly valid), because the <span class="code">&lt;emph&gt;</span> element is only supposed to be used when a writer is placing <em>strong emphasis</em> on a word or phrase. In this document, the <span class="code">&lt;emph&gt;</span> elements are being applied to designate non-English words and book titles, so this tagging is not really for emphasis. We really should be using the TEI <span class="code">&lt;hi rend="italic"&gt;</span> tagging for these instead, since this element is designated for highlighting of any kind.</li>
+      </ul>
+         <p>You may already be calculating how to do these tasks with a regular expression Find and Replace, and while we know you could do that, our purpose with this exercise is to make the changes using an XSLT transformation, and we hope you will learn some things about how XSLT works through this exercise! </p>
+      <p>To begin, open a new XSLT stylesheet in &lt;oXygen&gt; and switch to the XSLT view. We will have some housekeeping to do as we get started.</p>
+      <h3>Namespaces matter! Setting up an XSLT stylesheet to Read TEI</h3>
+
+      <p>Georg Forster’s <cite>A Voyage Round the World</cite> is coded in the TEI namespace, which means that your XSLT stylesheet
+         must include an instruction at the top to specify that when it tries to match elements, it needs to
+         match them in that TEI namespace. When you create a new XSLT document in &lt;oXygen/&gt; it
+         won’t contain that instruction by default, so <em>whenever you are working with TEI</em> you need to add it (See the text in <span style="color:blue;">blue</span> below). We also need to make sure that our XSLT parser understands it is outputting results to the TEI namespace, so we change one more line (See the text in <span style="color:red;">red</span> below).Our modified stylesheet template looks like the following:</p>
+      <pre>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    <span style="color:blue;">xpath-default-namespace="http://www.tei-c.org/ns/1.0"</span>
+    <span style="color:red;">xmlns="http://www.tei-c.org/ns/1.0"</span>
+    <span style="color:purple;">version="3.0"</span>>
+    
+&lt;/xsl:stylesheet&gt;</pre>
+      
+      
+      <h3>Writing the Identity Transformation!</h3>
+      
+      
+     <ol> <li>We will give you your first template rule, to set this as an <em>identity transformation</em>. We’re going to use a new form for this in version XSLT 3.0,
+        so that is why we have set <code>version="3.0"</code> in our stylesheet template above. On future assignments we are setting the default version 2.0 for tranforming to HTML mostly because the old version is better tested for processing HTML output, but for an identity transformation of XML to XML, we like the efficient new code we can write in version 3.0. <span class="smaller">(You can see an old form here in the first template rule of our Identity transformation of Shakespeare’s sonnets, which you can download, save and open from <a href="SonnetIDTransform.xsl">here</a>. That old first rule matches on all nodes, elements and attributes throughout the document and simply copies them. It’s perfectly fine to use that older template rule in place of the one we show you below, but we like the simplicity of this new form even better!)</span>.
+      <div class="code">
+         &lt;xsl:mode on-no-match="shallow-copy"/&gt; 
+      </div>
+      <p> This XSLT statement is the <em>opposite</em> of the <span class="code">xsl:template match</span> we have been showing you in <a href="explainXSLT.html">our XSLT tutorial</a>. You basically say, if I do not write a template rule to <em>match</em> an element, attribute, or comment node, really of any part of the document that I do not mention in a template match rule, XSLT should simply make a copy of that element and output it. Try running this and look at your output: it will look exactly <em>identical</em> to the current XML document. Obviously we do not need to do this <em>unless</em> we want to make changes with template match rules! 
+      <span class="smaller">There is another way to copy, called "deep copy" in XSLT, but we do not want use it here. When you use "deep copy" in XSLT, you reproduce the full directory tree underneath a given element, so the understanding is that we would match on the root element <em>only</em>, and reproduce all the descendents of that one node just as they are. We like the "on-no-match-shallow-copy" approach because we do not necessarily want to copy every node just as it is in the original. We only want to copy if it we do not want to write a new template rule that will change it. </span></p>
+     </li>
+        <li>Next, we will simply write our template rules to match on the particular elements we wish to change. You may wish to start with the simpler of the two, to convert all the <span class="code">&lt;emph&gt;</span> elements into <span class="code">&lt;hi rend="italics"&gt;</span> in the output XML. Review our <a href="explainXSLT.html">Introduction to XSLT</a> to see how to write a template match on any particular element, and how to output as a different element in its place using <span class="code">&lt;xsl:apply-templates/&gt;</span>.</li>
+        <li>Now, write the template rule that will match <em>only</em> on <span class="code">&lt;l&gt;</span> elements that are children of <span class="code">&lt;head&gt;</span> elements. And see if you can figure out how to replace these by positioning the self-closing line-break element <span class="code">&lt;lb/&gt;</span>, positioned in the correct spot in relation to <span class="code">&lt;xsl:apply-templates/&gt;</span> so that the <span class="code">&lt;lb/&gt;</span> sits at the end of a line.</li>
+      
+      
+      			
+      <li>We often use an Identity transformation with Attribute Value Templates, in order to add attributes to elements like <span class="code">&lt;p&gt;</span> or <span class="code">&lt;l&gt;</span> that calculate a paragraph or line number. We have already numbered the paragraphs in the Forster file, but as your final challenge for this assignment, read about <a href="http://dh.obdurodon.org/avt.xhtml">Attribute Value Templates</a> and write two more template rules to add <span class="code">@n</span> attributes to automatically number the <span class="code">&lt;div&gt;</span> elements for Books, and the <span class="code">&lt;div&gt;</span> elements for Chapters. (Hint: Look at my old example ID-transform stylesheet that adds line numbers to a series of sonnets, downloadable from <a href="SonnetIDTransform.xsl">here</a> if you didn’t download it earlier.) We will return to this later, since you will be working with Attribute Value Templates in <a href="XSLTExercise3_CDV.html">XSLT Exercise 3</a>.</li>
+     </ol>
+      <p>When you are finished, save your XSLT file and your XML output of the Georg Forster file, following our usual <a href="http://dh.obdurodon.org/file-naming_conventions.xhtml">homework file naming conventions</a>, and upload these to the appropriate place in Courseweb.</p>					
+    
+   </body>
+   
+   
+   
+   
+</html>


### PR DESCRIPTION
In case you don't want to change the optional challenge for the CDA class I copied the CDA XSLT Exercise 1 into the CDV folder renamed it so that it has the _CDV ending and then made the changes there so that the AVT numbering is now a required challenge. @ebeshero this needs uploaded to the newtFire site (now all three of the XSLT exercises for the CDV course can be uploaded to newtFire and they all have the _CDV ending as soon as possible since students are assigned this today. XSLTExercise3_CDV is still under development and will be done before the weekend. 
